### PR TITLE
New effect: Disable car respray

### DIFF
--- a/src/gtasa/effects/custom/vehicle/DisablePayNSprayEffect.cpp
+++ b/src/gtasa/effects/custom/vehicle/DisablePayNSprayEffect.cpp
@@ -1,0 +1,35 @@
+#include "util/EffectBase.h"
+#include <extensions/ScriptCommands.h>
+
+using namespace plugin;
+
+class DisablePayNSprayEffect : public EffectBase
+{
+public:
+    void
+    OnTick (EffectInstance *inst) override
+    {
+        Command<eScriptCommands::COMMAND_CHANGE_GARAGE_TYPE> ("modlast", 0);
+        Command<eScriptCommands::COMMAND_CHANGE_GARAGE_TYPE> ("mds1SFS", 0);
+        Command<eScriptCommands::COMMAND_CHANGE_GARAGE_TYPE> ("bodLAwN", 0);
+        Command<eScriptCommands::COMMAND_CHANGE_GARAGE_TYPE> ("mdsSFSe", 0);
+        Command<eScriptCommands::COMMAND_CHANGE_GARAGE_TYPE> ("vEcmod", 0);
+
+        Command<eScriptCommands::COMMAND_SET_NO_RESPRAYS> (true);
+    }
+
+    void
+    OnEnd (EffectInstance *inst) override
+    {
+        Command<eScriptCommands::COMMAND_CHANGE_GARAGE_TYPE> ("modlast", 36);
+        Command<eScriptCommands::COMMAND_CHANGE_GARAGE_TYPE> ("mds1SFS", 37);
+        Command<eScriptCommands::COMMAND_CHANGE_GARAGE_TYPE> ("bodLAwN", 38);
+        Command<eScriptCommands::COMMAND_CHANGE_GARAGE_TYPE> ("mdsSFSe", 38);
+        Command<eScriptCommands::COMMAND_CHANGE_GARAGE_TYPE> ("vEcmod", 38);
+
+        Command<eScriptCommands::COMMAND_SET_NO_RESPRAYS> (false);
+    }
+};
+
+DEFINE_EFFECT (DisablePayNSprayEffect, "effect_disable_pay_n_spray",
+               GROUP_VEHICLE_COLOR);


### PR DESCRIPTION
The effect disables the pay'n'spray garages. They will be open, but nothing happens if the player goes inside.
The effect also disables TransFender etc garages.

Garages list: https://gtamods.com/wiki/Garage#San_Andreas_2