### PR TITLE
New effect: low draw distance; mist

### DIFF
--- a/src/gtasa/effects/custom/unsorted/LowDrawDistanceEffect.cpp
+++ b/src/gtasa/effects/custom/unsorted/LowDrawDistanceEffect.cpp
@@ -1,0 +1,17 @@
+#include "util/EffectBase.h"
+
+#include <CTimeCycle.h>
+
+class LowDrawDistanceEffect : public EffectBase
+{
+public:
+    void
+    OnTick (EffectInstance *inst) override
+    {
+        CTimeCycle::m_CurrentColours.m_fFarClip = 200.0f;
+    }
+};
+
+DEFINE_EFFECT (LowDrawDistanceEffect, "effect_low_draw_distance",
+               GROUP_NPC_SPAWNS | GROUP_CAMERA | GROUP_VISION
+                   | GROUP_VEHICLE_RARITY);

--- a/src/gtasa/effects/custom/unsorted/MistEffect.cpp
+++ b/src/gtasa/effects/custom/unsorted/MistEffect.cpp
@@ -1,0 +1,37 @@
+#include "util/EffectBase.h"
+
+#include <CClock.h>
+#include <CTimeCycle.h>
+#include <CWeather.h>
+
+class MistEffect : public EffectBase
+{
+private:
+    int forceWeather = WEATHER_FOGGY_SF;
+
+public:
+    void
+    OnStart (EffectInstance *inst) override
+    {
+        constexpr int weathers[]
+            = {WEATHER_RAINY_SF, WEATHER_FOGGY_SF, WEATHER_RAINY_COUNTRYSIDE,
+               WEATHER_SANDSTORM_DESERT};
+
+        auto idx     = inst->Random (0, 10000) % std::size (weathers);
+        forceWeather = weathers[idx];
+    }
+
+    void
+    OnTick (EffectInstance *inst) override
+    {
+        CClock::ms_nGameClockHours   = 0;
+        CClock::ms_nGameClockMinutes = 0;
+        CClock::ms_nGameClockSeconds = 0;
+        CWeather::ForceWeatherNow (forceWeather);
+        CTimeCycle::m_CurrentColours.m_fFarClip = 150.0f;
+    }
+};
+
+DEFINE_EFFECT (MistEffect, "effect_mist",
+               GROUP_NPC_SPAWNS | GROUP_CAMERA | GROUP_VISION | GROUP_WEATHER
+                   | GROUP_VEHICLE_RARITY);


### PR DESCRIPTION
Two new effects: low draw distance #147 and mist (low draw dist + midnight + change weather).
Change the draw distance also affects on peds and cars spawns.
100 is the minimum OK for low distance. So I think that from 100 to 300 will be enough for the effect.