### PR TITLE
Make fake wasted busted state more realistic

### DIFF
--- a/src/gtasa/effects/custom/player/GetWastedBustedFakeEffect.cpp
+++ b/src/gtasa/effects/custom/player/GetWastedBustedFakeEffect.cpp
@@ -1,5 +1,7 @@
 #include "util/EffectBase.h"
 #include "util/GenericUtil.h"
+#include "util/hooks/HookMacros.h"
+
 #include <extensions/ScriptCommands.h>
 
 enum class FakeEffectType
@@ -8,7 +10,7 @@ enum class FakeEffectType
     BUSTED
 };
 
-constexpr int FADE_IN_TIME       = 5000;
+constexpr int   FADE_IN_TIME           = 5000;
 constexpr float FADE_IN_TIME_FLOAT     = FADE_IN_TIME * 0.001f;
 constexpr float FADE_OUT_TIME_FLOAT    = 1.0f;
 constexpr int   WAIT_TO_FADE_OUT_START = FADE_IN_TIME + 500;
@@ -20,6 +22,8 @@ class GetWastedBustedFake : public EffectBase
     FakeEffectType type;
     int            wait = 0;
 
+    static inline bool skipBlipRender{};
+
 public:
     GetWastedBustedFake () = delete;
 
@@ -28,11 +32,23 @@ public:
     void
     OnStart (EffectInstance *inst) override
     {
+        HOOK_ARGS (inst, Hooked_CRadar_ShowRadarTraceWithHeight,
+                   void (float, float, std::uint32_t, std::uint32_t,
+                         std::uint32_t, std::uint32_t, std::uint32_t,
+                         std::uint8_t),
+                   0x584070);
+
         inst->SetIsOneTimeEffect ();
         inst->SetTimerVisible (false);
 
+        skipBlipRender = true;
         std::string msg (type == FakeEffectType::WASTED ? "DEAD" : "BUSTED");
         Command<Commands::CLEAR_SMALL_PRINTS> ();
+        Command<Commands::SET_EVERYONE_IGNORE_PLAYER> (0, true);
+        Command<Commands::SET_POLICE_IGNORE_PLAYER> (0, true);
+        Command<Commands::CLEAR_MISSION_AUDIO> (1);
+        Command<Commands::CLEAR_MISSION_AUDIO> (2);
+        Command<Commands::CLEAR_HELP> ();
         Command<eScriptCommands::COMMAND_PRINT_BIG> (msg.data (), FADE_IN_TIME,
                                                      3);
 
@@ -43,7 +59,7 @@ public:
         }
 
         TheCamera.Fade (FADE_IN_TIME_FLOAT, 0);
-        
+
         auto *player = FindPlayerPed ();
         if (!player) return;
 
@@ -69,7 +85,7 @@ public:
 
         auto *pad = player->GetPadFromPlayer ();
         if (!pad) return;
-        
+
         pad->DisablePlayerControls = true;
 
         wait += int (GenericUtil::CalculateTick ());
@@ -84,15 +100,31 @@ public:
 
             Command<eScriptCommands::COMMAND_RESTORE_CAMERA> ();
 
-            TheCamera.Fade (FADE_OUT_TIME_FLOAT, 1);            
+            TheCamera.Fade (FADE_OUT_TIME_FLOAT, 1);
 
-            pad->DisablePlayerControls = false;            
+            Command<Commands::SET_EVERYONE_IGNORE_PLAYER> (0, false);
+            Command<Commands::SET_POLICE_IGNORE_PLAYER> (0, false);
 
-            wait = 0;
+            pad->DisablePlayerControls = false;
+
+            wait           = 0;
+            skipBlipRender = false;
 
             inst->OverrideName (std::string (inst->GetName ()) + "?");
             inst->Disable ();
         }
+    }
+
+    static void
+    Hooked_CRadar_ShowRadarTraceWithHeight (auto &&cb, float x, float y,
+                                            std::uint32_t size, std::uint32_t R,
+                                            std::uint32_t G, std::uint32_t B,
+                                            std::uint32_t A,
+                                            std::uint8_t  height)
+    {
+        if (skipBlipRender) return;
+
+        cb ();
     }
 };
 


### PR DESCRIPTION
This is not an ideal implementation of state, but it does much more than just fade in/out.
Now the blips on the radar (squares and triangles) will not be rendered.
The current audio will be stopped.
Peds and cops will ignore the player.